### PR TITLE
Add tag span.type web on muxtrace

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -12,6 +12,10 @@ import (
 func TraceAndServe(h http.Handler, w http.ResponseWriter, r *http.Request, service, resource string, spanopts ...opentracing.StartSpanOption) {
 	opts := append([]opentracing.StartSpanOption{
 		opentracing.Tag{
+			Key:   "span.type",
+			Value: "web",
+		},
+		opentracing.Tag{
 			Key:   "http.method",
 			Value: r.Method,
 		},


### PR DESCRIPTION
- add tag span.type web, in order to get ApDex calculated on datadog. 